### PR TITLE
Rework baud rate for esptool

### DIFF
--- a/src/multiStepInput.ts
+++ b/src/multiStepInput.ts
@@ -19,7 +19,7 @@ export async function multiStepInput(context: ExtensionContext, nanoFrameworkExt
 	const dfuJtagOptions: QuickPickItem[] = ['DFU mode','JTAG mode']
 		.map(label => ({ label }));
 
-    const baudRates: QuickPickItem[] = ['9600','19200','38400','57600','115200','230400','460800','921600','1288000']
+    const baudRates: QuickPickItem[] = ['1500000','115200']
 		.map(label => ({ label }));
 
 	interface State {


### PR DESCRIPTION
## Description
- Add 1500000 as default and left 115200 for slower devices.

## Motivation and Context
- No need to offer all those baud rates for esptool. 99% of the ESP32 devices we support will work just fine with 1M5.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
